### PR TITLE
fix: Update WASM source link to reflect new repo

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -33,8 +33,8 @@
 	    </div>
 	</main>
 	<footer>
-	    <a href="https://github.com/38/plotters/blob/master/examples/wasm-demo" target="a">Source</a> |
-	    <a href="https://github.com/38/plotters" target="a">Repo</a> |
+	    <a href="https://github.com/plotters-rs/plotters-wasm-demo" target="a">Source</a> |
+	    <a href="https://github.com/plotters-rs/plotters" target="a">Repo</a> |
 	    <a href="https://crates.io/crates/plotters" target="a">Crates</a> |
 	    <a href="https://docs.rs/plotters" target="a">Docs</a>
 	</footer>


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

This also needs to be re-deployed to fix the `Source` link at https://plotters-rs.github.io/wasm-demo/www/index.html